### PR TITLE
feat: Implement matrix builds for Docker platforms ARM7, ARCH64, AMD64

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -151,7 +151,10 @@ jobs:
   docker:
     needs: check-release
     runs-on: ubuntu-latest
-    continue-on-error: true
+    fail-fast: false
+    strategy:  # Added this new section
+      matrix:
+        platform: [linux/arm/v7, linux/arm64, linux/amd64]
     steps:
       - uses: actions/checkout@v4
 
@@ -172,7 +175,7 @@ jobs:
         with:
           context: .
           push: true
-          platforms: linux/amd64,linux/arm64
+          platforms: ${{ matrix.platform }}          
           tags: |
             ${{ secrets.DOCKERHUB_USERNAME }}/infrarust:latest
             ${{ secrets.DOCKERHUB_USERNAME }}/infrarust:${{ needs.check-release.outputs.version }}


### PR DESCRIPTION
Fixes #17

Changes made:
- Implemented matrix strategy for Docker builds
- Set specific platform targets: linux/arm/v7, linux/arm64, linux/amd64
- Added fail-fast: false to allow builds to complete even if one platform fails
- Removed continue-on-error to ensure build failures are properly reported

This change improves the CI/CD pipeline by building each platform in parallel and focuses on the three required platforms.