### PR TITLE
Fix docker runtime not including required libraries

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,19 +1,40 @@
-FROM rust:1.84-slim AS builder
+ARG RUST_VERSION=1.85
+ARG DEBIAN_VERSION=bookworm
+ARG DEBIAN_VERSION_NUMBER=12
+
+FROM rust:${RUST_VERSION}-slim-${DEBIAN_VERSION} AS builder
 WORKDIR /usr/src/infrarust
-RUN apt update && apt install -y pkg-config libssl-dev
+
+# Prevent deletion of apt cache
+RUN rm -f /etc/apt/apt.conf.d/docker-clean
+
+RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
+    --mount=type=cache,target=/var/lib/apt,sharing=locked \
+    apt update && apt install -y pkg-config libssl-dev
+
+# Create config directory for runtime
+RUN mkdir -p /rootfs/app/config
+
 COPY Cargo.toml Cargo.lock ./
 COPY src/ ./src/
-RUN cargo build --release
+RUN mkdir sbin
+
+RUN --mount=type=cache,target=/usr/local/cargo/registry \
+    --mount=type=cache,target=/usr/local/cargo/git/db \
+    --mount=type=cache,target=/usr/src/infrarust/target \
+    cargo build --release & \
+    cp target/release/infrarust sbin/
 
 
-FROM alpine:3.14
+# FROM debian:${DEBIAN_VERSION}-slim
+FROM gcr.io/distroless/cc-debian${DEBIAN_VERSION_NUMBER}
 WORKDIR /app
 
-COPY --from=builder /usr/src/infrarust/target/release/infrarust /app/
-RUN mkdir /app/config
+COPY --from=builder /rootfs/ /
+COPY --from=builder /usr/src/infrarust/sbin /sbin
 
 VOLUME ["/app/config"]
 EXPOSE 25565
 
-ENTRYPOINT ["/app/infrarust"]
+ENTRYPOINT ["/sbin/infrarust"]
 CMD ["--config-path", "/app/config/config.yaml", "--proxies-path", "/app/config/proxies"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -22,7 +22,7 @@ RUN mkdir sbin
 RUN --mount=type=cache,target=/usr/local/cargo/registry \
     --mount=type=cache,target=/usr/local/cargo/git/db \
     --mount=type=cache,target=/usr/src/infrarust/target \
-    cargo build --release & \
+    cargo build --release ; \
     cp target/release/infrarust sbin/
 
 


### PR DESCRIPTION
Running the docker image gives the following error right now:

> exec container process (missing dynamic library?) `/app/infrarust`: No such file or directory

This PR fixes that.

Additionally:
- extracts hardcoded versions into variables
- bumps rust version
- adds cache mounts for faster local builds

The runtime image, originally based on Alpine, was incompatible with the built binaries. Critically, it was missing glibc, although openssl could also have been an issue. To fix that, we're now using a compatible, glibc-based, base image. 

I've picked Google's Distroless image as a good, small base. You could also use Debian Slim, but that results in a significantly larger image. There are other options that result in smaller images, but this is one of the simplest - and the priority is to have something that works.