### PR TITLE
Domain configuration selection: add specificity-based matching logic and comprehensive tests

### DIFF
--- a/crates/infrarust/src/core/config/service.rs
+++ b/crates/infrarust/src/core/config/service.rs
@@ -88,8 +88,8 @@ impl ConfigurationService {
         best_match
     }
     
-    /// Calculate domain specificity score for sorting
-    /// Higher score = more specific = should be checked first
+    /// Calculates the domain specificity score for sorting.
+    /// Higher scores indicate more specific patterns, which should be checked first.
     fn calculate_pattern_specificity(pattern: &str) -> i32 {
         let pattern_lower = pattern.to_lowercase();
         


### PR DESCRIPTION
This pull request improves the domain matching logic in the `ConfigurationService` by introducing specificity-based selection for server configurations and adds comprehensive tests to verify the new behavior. Now, when multiple configurations match a domain (including wildcards), the most specific one is reliably chosen.

### Domain Matching Logic Improvements

* Updated the `find_server_by_domain` method to collect all matching configurations and select the most specific one using a calculated specificity score, ensuring exact matches and more specific wildcards take precedence.
* Added a new `calculate_domain_specificity` helper method to score domain patterns, giving highest priority to exact matches and ranking wildcards by number of non-wildcard segments and overall pattern depth.

### Testing Enhancements

* Added async tests for domain matching, including cases for exact matches, multiple wildcards, and deeply nested wildcards, ensuring the new specificity logic works as intended.
* Included the necessary imports and setup for the new test cases in the test module.