### PR TITLE
feat: add support for socket activation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -651,6 +651,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "command-fds"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1b60b5124979fccd9addd89d8b97a1d6eebb4950694520c75ddd722535ea443f"
+dependencies = [
+ "nix",
+ "thiserror 2.0.18",
+]
+
+[[package]]
 name = "compression-codecs"
 version = "0.4.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2185,9 +2195,12 @@ name = "infrarust-transport"
 version = "2.0.0-beta.1"
 dependencies = [
  "bytes",
+ "command-fds",
  "infrarust_config",
+ "listenfd",
  "nix",
  "ppp",
+ "rusty-fork",
  "socket2",
  "thiserror 2.0.18",
  "tokio",
@@ -2487,6 +2500,17 @@ name = "linux-raw-sys"
 version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a66949e030da00e8c7d4434b251670a91556f4144941d37452769c25d58a53"
+
+[[package]]
+name = "listenfd"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b87bc54a4629b4294d0b3ef041b64c40c611097a677d9dc07b2c67739fe39dba"
+dependencies = [
+ "libc",
+ "uuid",
+ "winapi",
+]
 
 [[package]]
 name = "litemap"
@@ -3172,6 +3196,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "quick-error"
+version = "1.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a1d01941d82fa2ab50be1e79e6714289dd7cde78eba4c074bc5a4374f650dfe0"
+
+[[package]]
 name = "quinn"
 version = "0.11.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3673,6 +3703,18 @@ name = "rustversion"
 version = "1.0.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
+
+[[package]]
+name = "rusty-fork"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cc6bf79ff24e648f6da1f8d1f011e9cac26491b619e6b9280f2b47f1774e6ee2"
+dependencies = [
+ "fnv",
+ "quick-error",
+ "tempfile",
+ "wait-timeout",
+]
 
 [[package]]
 name = "ryu"
@@ -4593,6 +4635,15 @@ name = "version_check"
 version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
+
+[[package]]
+name = "wait-timeout"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09ac3b126d3914f9849036f826e054cbabdc8519970b8998ddaf3b5bd3c65f11"
+dependencies = [
+ "libc",
+]
 
 [[package]]
 name = "walkdir"

--- a/crates/infrarust-transport/Cargo.toml
+++ b/crates/infrarust-transport/Cargo.toml
@@ -18,9 +18,12 @@ ppp = { workspace = true }
 thiserror = { workspace = true }
 tracing = { workspace = true }
 infrarust_config = { workspace = true }
+listenfd = "1.0.2"
 
 [target.'cfg(target_os = "linux")'.dependencies]
 nix = { workspace = true }
 
 [dev-dependencies]
+command-fds = "0.3.3"
+rusty-fork = "0.3.1"
 tokio = { workspace = true, features = ["test-util"] }

--- a/crates/infrarust-transport/src/error.rs
+++ b/crates/infrarust-transport/src/error.rs
@@ -14,6 +14,9 @@ pub enum TransportError {
         source: std::io::Error,
     },
 
+    #[error("socket file descriptor error: {0}")]
+    SocketFileDescriptor(std::io::Error),
+
     /// Failed to accept incoming connection.
     #[error("accept error: {0}")]
     Accept(std::io::Error),

--- a/crates/infrarust-transport/src/socket.rs
+++ b/crates/infrarust-transport/src/socket.rs
@@ -6,6 +6,7 @@
 
 use std::net::SocketAddr;
 
+use listenfd::ListenFd;
 use socket2::{Domain, Protocol, Socket, TcpKeepalive, Type};
 use tokio::net::{TcpListener, TcpStream};
 
@@ -14,6 +15,8 @@ use infrarust_config::KeepaliveConfig;
 use crate::error::TransportError;
 
 /// Creates and configures a listener socket.
+/// If socket activation (`LISTEN_FDS` env var) is configured,
+/// that socket is used instead of creating a new one.
 ///
 /// Sets `SO_REUSEADDR` (always), `SO_REUSEPORT` (Linux, if requested),
 /// nonblocking mode, then binds and listens with a backlog of 1024.
@@ -21,11 +24,25 @@ use crate::error::TransportError;
 /// # Errors
 ///
 /// Returns [`TransportError::SocketConfig`] if socket creation or
-/// configuration fails, or [`TransportError::Bind`] if binding fails.
+/// configuration fails, [`TransportError::Bind`] if binding fails,
+/// or [`TransportError::SocketFileDescriptor`] if socket activation
+/// fails.
 pub fn configure_listener_socket(
     addr: SocketAddr,
     reuseport: bool,
 ) -> Result<Socket, TransportError> {
+    // Check for socket activation and use a socket on a file descriptor if available
+    #[cfg(any(target_os = "linux", target_os = "macos"))]
+    {
+        let mut listenfd = ListenFd::from_env();
+        if let Some(listener) = listenfd
+            .take_tcp_listener(0)
+            .map_err(TransportError::SocketFileDescriptor)?
+        {
+            return Ok(Socket::from(listener));
+        }
+    }
+
     let domain = if addr.is_ipv4() {
         Domain::IPV4
     } else {

--- a/crates/infrarust-transport/tests/socket.rs
+++ b/crates/infrarust-transport/tests/socket.rs
@@ -1,7 +1,10 @@
 #![allow(clippy::unwrap_used, clippy::expect_used)]
+use command_fds::{CommandFdExt, FdMapping};
 use infrarust_config::KeepaliveConfig;
 use infrarust_transport::socket::*;
+use rusty_fork::{fork, rusty_fork_id};
 use std::net::SocketAddr;
+use std::os::fd::AsFd;
 use std::time::Duration;
 
 #[test]
@@ -10,6 +13,59 @@ fn test_configure_listener_socket_binds() {
     let socket = configure_listener_socket(addr, false).unwrap();
     let local = socket.local_addr().unwrap();
     assert!(local.as_socket().unwrap().port() > 0);
+}
+
+#[cfg(any(target_os = "linux", target_os = "macos"))]
+#[test]
+fn test_configure_listener_socket_activation() {
+    let fork_result = fork(
+        "test_configure_listener_socket_activation",
+        rusty_fork_id!(),
+        move |cmd: &mut std::process::Command| {
+            let addr: SocketAddr = "127.0.0.1:0".parse().unwrap();
+            let bound_socket = configure_listener_socket(addr, false).unwrap();
+            let bound_port = bound_socket
+                .local_addr()
+                .unwrap()
+                .as_socket()
+                .unwrap()
+                .port();
+            println!("Port: {}", bound_port);
+
+            cmd.fd_mappings(vec![FdMapping {
+                parent_fd: bound_socket.as_fd().try_clone_to_owned().unwrap(),
+                child_fd: 3,
+            }])
+            .unwrap();
+
+            cmd.env("LISTEN_FDS", "1");
+            cmd.env("TEST_PORT_SHOULD_BE", bound_port.to_string());
+        },
+        |child, _| {
+            let status = child.wait().unwrap();
+            assert!(
+                status.success(),
+                "child process failed with exit code: {:?}",
+                status.code()
+            );
+        },
+        || {
+            let addr: SocketAddr = "127.0.0.1:0".parse().unwrap();
+            let activated_socket = configure_listener_socket(addr, false).unwrap();
+            let activated_port = activated_socket
+                .local_addr()
+                .unwrap()
+                .as_socket()
+                .unwrap()
+                .port();
+            let bound_port = std::env::var("TEST_PORT_SHOULD_BE")
+                .unwrap()
+                .parse::<u16>()
+                .unwrap();
+            assert!(bound_port == activated_port);
+        },
+    );
+    fork_result.expect("Fork failed");
 }
 
 #[test]


### PR DESCRIPTION
closes #91

Adds support for socket activation on linux. This enables native network performance and source IP preservation when using rootless container networking.

I added a couple of crates for testing. Testing this feature was a bit tricky; I simulated socket activation by passing a previously-bound socket as a FD to a self-fork and making sure the port numbers are the same.
Let me know if you think of a cleaner way to test this.