### PR TITLE
Fix Velocity forwarding in intercepted modes and support Minecraft 26.2

### DIFF
--- a/crates/infrarust-core/src/forwarding/mod.rs
+++ b/crates/infrarust-core/src/forwarding/mod.rs
@@ -56,6 +56,11 @@ pub enum ForwardingHandler {
 }
 
 impl ForwardingHandler {
+    /// Returns whether this handler uses Velocity modern forwarding.
+    pub const fn is_velocity(&self) -> bool {
+        matches!(self, Self::Velocity(_))
+    }
+
     pub const fn modifies_handshake(&self) -> bool {
         matches!(self, Self::Legacy(_) | Self::BungeeGuard(_))
     }

--- a/crates/infrarust-core/src/handler/intercepted/auth.rs
+++ b/crates/infrarust-core/src/handler/intercepted/auth.rs
@@ -1,6 +1,6 @@
 //! Authentication strategy for intercepted proxy modes.
 
-use std::sync::Arc;
+use std::sync::{Arc, OnceLock};
 
 use infrarust_api::event::ResultedEvent;
 use infrarust_api::events::lifecycle::PreLoginResult;
@@ -338,12 +338,17 @@ pub(super) async fn send_login_success(
     version: ProtocolVersion,
     registry: &PacketRegistry,
 ) -> Result<(), CoreError> {
+    static SESSION_ID: OnceLock<uuid::Uuid> = OnceLock::new();
+
     let login_success = CLoginSuccess {
         uuid,
         username: username.to_string(),
         properties: properties.to_vec(),
         strict_error_handling: version.no_less_than(ProtocolVersion::V1_20_5)
             && version.no_greater_than(ProtocolVersion::V1_21),
+        session_id: version
+            .no_less_than(ProtocolVersion::V26_2)
+            .then(|| *SESSION_ID.get_or_init(uuid::Uuid::new_v4)),
     };
 
     client.send_packet(&login_success, registry).await?;

--- a/crates/infrarust-core/src/handler/intercepted/initial_connect.rs
+++ b/crates/infrarust-core/src/handler/intercepted/initial_connect.rs
@@ -180,6 +180,11 @@ pub(super) async fn resolve_initial_mode(
     let mode = if let Some(limbo_mode) = initial_mode {
         limbo_mode
     } else {
+        let forwarding_handler = services.resolve_forwarding_handler(server_config);
+        if requires_proxy_completed_login(&forwarding_handler, *login_completed) {
+            ensure_login_complete(client, auth_result, login_completed, version, services).await?;
+        }
+
         match connect_to_backend(
             client,
             auth_result,
@@ -304,7 +309,11 @@ async fn connect_to_backend(
                 .await?;
         }
 
-        let velocity_ctx = services.forwarding_secret().map(|s| (&fwd_data, s));
+        let velocity_ctx = if handler.is_velocity() {
+            services.forwarding_secret().map(|s| (&fwd_data, s))
+        } else {
+            None
+        };
 
         if let Err(e) = backend
             .consume_backend_login(&services.packet_registry, version, velocity_ctx)
@@ -358,8 +367,7 @@ async fn prepare_client_for_limbo(
     version: ProtocolVersion,
     services: &ProxyServices,
 ) -> Result<(), CoreError> {
-    ensure_login_complete_for_limbo(client, auth_result, login_completed, version, services)
-        .await?;
+    ensure_login_complete(client, auth_result, login_completed, version, services).await?;
 
     if version.no_less_than(ProtocolVersion::V1_20_2)
         && let Err(e) = crate::limbo::login::complete_config_for_limbo(
@@ -381,7 +389,7 @@ async fn prepare_client_for_limbo(
     Ok(())
 }
 
-async fn ensure_login_complete_for_limbo(
+async fn ensure_login_complete(
     client: &mut ClientBridge,
     auth_result: &AuthResult,
     login_completed: &mut bool,
@@ -410,4 +418,30 @@ async fn ensure_login_complete_for_limbo(
 
     *login_completed = true;
     Ok(())
+}
+
+const fn requires_proxy_completed_login(
+    handler: &crate::forwarding::ForwardingHandler,
+    login_completed: bool,
+) -> bool {
+    handler.is_velocity() && !login_completed
+}
+
+#[cfg(test)]
+mod tests {
+    use super::requires_proxy_completed_login;
+    use crate::forwarding::{ForwardingHandler, ForwardingMode, build_forwarding_handler};
+
+    #[test]
+    fn velocity_requires_proxy_completed_login_for_offline_flow() {
+        let velocity = build_forwarding_handler(&ForwardingMode::Velocity {
+            secret: b"test-secret".to_vec(),
+        });
+        assert!(requires_proxy_completed_login(&velocity, false));
+        assert!(!requires_proxy_completed_login(&velocity, true));
+        assert!(!requires_proxy_completed_login(
+            &ForwardingHandler::None,
+            false
+        ));
+    }
 }

--- a/crates/infrarust_protocol/src/packets/login.rs
+++ b/crates/infrarust_protocol/src/packets/login.rs
@@ -382,12 +382,14 @@ impl Packet for CSetCompression {
 ///
 /// Properties (skin/texture data) are only sent in 1.19+.
 /// `strict_error_handling` is only sent in 1.20.5 and 1.21.
+/// `session_id` is sent in 26.2+.
 #[derive(Debug, Clone)]
 pub struct CLoginSuccess {
     pub uuid: uuid::Uuid,
     pub username: String,
     pub properties: Vec<Property>,
     pub strict_error_handling: bool,
+    pub session_id: Option<uuid::Uuid>,
 }
 
 impl Packet for CLoginSuccess {
@@ -450,11 +452,18 @@ impl Packet for CLoginSuccess {
                 false
             };
 
+        let session_id = if version.no_less_than(ProtocolVersion::V26_2) {
+            Some(r.read_uuid()?)
+        } else {
+            None
+        };
+
         Ok(Self {
             uuid,
             username,
             properties,
             strict_error_handling,
+            session_id,
         })
     }
 
@@ -495,6 +504,13 @@ impl Packet for CLoginSuccess {
         // strict_error_handling: only 1.20.5 and 1.21
         if version == ProtocolVersion::V1_20_5 || version == ProtocolVersion::V1_21 {
             w.write_bool(self.strict_error_handling)?;
+        }
+
+        if version.no_less_than(ProtocolVersion::V26_2) {
+            let session_id = self.session_id.ok_or_else(|| {
+                ProtocolError::invalid("login success session ID is required for 26.2+")
+            })?;
+            w.write_uuid(&session_id)?;
         }
 
         Ok(())
@@ -699,6 +715,7 @@ mod tests {
             username: "Notch".to_string(),
             properties: Vec::new(),
             strict_error_handling: false,
+            session_id: None,
         };
         let decoded = round_trip(&pkt, ProtocolVersion::V1_8);
         assert_eq!(decoded.uuid, uuid);
@@ -725,6 +742,7 @@ mod tests {
                 },
             ],
             strict_error_handling: false,
+            session_id: None,
         };
         let decoded = round_trip(&pkt, ProtocolVersion::V1_19);
         assert_eq!(decoded.uuid, uuid);
@@ -743,6 +761,7 @@ mod tests {
             username: "Notch".to_string(),
             properties: Vec::new(),
             strict_error_handling: true,
+            session_id: None,
         };
         let decoded = round_trip(&pkt, ProtocolVersion::V1_20_5);
         assert!(decoded.strict_error_handling);
@@ -753,6 +772,22 @@ mod tests {
     }
 
     #[test]
+    fn test_login_success_v26_2_session_id() {
+        let uuid = uuid::Uuid::parse_str("069a79f4-44e9-4726-a5be-fca90e38aaf5").unwrap();
+        let session_id = uuid::Uuid::parse_str("11111111-2222-3333-4444-555555555555").unwrap();
+        let pkt = CLoginSuccess {
+            uuid,
+            username: "Notch".to_string(),
+            properties: Vec::new(),
+            strict_error_handling: false,
+            session_id: Some(session_id),
+        };
+
+        let decoded = round_trip(&pkt, ProtocolVersion::V26_2);
+        assert_eq!(decoded.session_id, Some(session_id));
+    }
+
+    #[test]
     fn test_login_success_v1_16_uuid_int_array() {
         let uuid = uuid::Uuid::parse_str("069a79f4-44e9-4726-a5be-fca90e38aaf5").unwrap();
         let pkt = CLoginSuccess {
@@ -760,6 +795,7 @@ mod tests {
             username: "Notch".to_string(),
             properties: Vec::new(),
             strict_error_handling: false,
+            session_id: None,
         };
         let decoded = round_trip(&pkt, ProtocolVersion::V1_16);
         assert_eq!(decoded.uuid, uuid);

--- a/crates/infrarust_protocol/src/registry/builder.rs
+++ b/crates/infrarust_protocol/src/registry/builder.rs
@@ -343,6 +343,7 @@ pub fn build_default_registry() -> PacketRegistry {
     .map(0x0B, ProtocolVersion::V1_20_5, false)
     .map(0x0D, ProtocolVersion::V1_21_2, false)
     .map(0x0E, ProtocolVersion::V1_21_6, false)
+    .map(0x0F, ProtocolVersion::V26_1, false)
     .register(&mut registry);
 
     PacketRegistration::<crate::packets::CTabCompleteResponse>::new(
@@ -383,6 +384,7 @@ pub fn build_default_registry() -> PacketRegistry {
     .map(0x27, ProtocolVersion::V1_21_2, false)
     .map(0x26, ProtocolVersion::V1_21_5, false)
     .map(0x2B, ProtocolVersion::V1_21_9, false)
+    .map(0x2C, ProtocolVersion::V26_1, false)
     .register(&mut registry);
 
     // Disconnect Clientbound (Play)
@@ -430,6 +432,7 @@ pub fn build_default_registry() -> PacketRegistry {
     .map(0x2C, ProtocolVersion::V1_21_2, true)
     .map(0x2B, ProtocolVersion::V1_21_5, true)
     .map(0x30, ProtocolVersion::V1_21_9, true)
+    .map(0x31, ProtocolVersion::V26_1, true)
     .register(&mut registry);
 
     // Respawn Clientbound (encode-only: proxy doesn't intercept)
@@ -457,6 +460,7 @@ pub fn build_default_registry() -> PacketRegistry {
     .map(0x4C, ProtocolVersion::V1_21_2, true)
     .map(0x4B, ProtocolVersion::V1_21_5, true)
     .map(0x50, ProtocolVersion::V1_21_9, true)
+    .map(0x52, ProtocolVersion::V26_1, true)
     .register(&mut registry);
 
     // PluginMessage Clientbound (encode-only: proxy doesn't intercept)
@@ -509,6 +513,7 @@ pub fn build_default_registry() -> PacketRegistry {
     .map(0x73, ProtocolVersion::V1_21_2, true)
     .map(0x72, ProtocolVersion::V1_21_5, true)
     .map(0x77, ProtocolVersion::V1_21_9, true)
+    .map(0x79, ProtocolVersion::V26_1, true)
     .register(&mut registry);
 
     // Legacy Title Clientbound (pre-1.17, 1.8+, encode-only)
@@ -541,6 +546,7 @@ pub fn build_default_registry() -> PacketRegistry {
     .map(0x6C, ProtocolVersion::V1_21_2, true)
     .map(0x6B, ProtocolVersion::V1_21_5, true)
     .map(0x70, ProtocolVersion::V1_21_9, true)
+    .map(0x72, ProtocolVersion::V26_1, true)
     .register(&mut registry);
 
     // SetSubtitle Clientbound (encode-only: injected by plugin system)
@@ -559,6 +565,7 @@ pub fn build_default_registry() -> PacketRegistry {
     .map(0x6A, ProtocolVersion::V1_21_2, true)
     .map(0x69, ProtocolVersion::V1_21_5, true)
     .map(0x6E, ProtocolVersion::V1_21_9, true)
+    .map(0x70, ProtocolVersion::V26_1, true)
     .register(&mut registry);
 
     // SetTitleTimes Clientbound (encode-only: injected by plugin system)
@@ -577,6 +584,7 @@ pub fn build_default_registry() -> PacketRegistry {
     .map(0x6D, ProtocolVersion::V1_21_2, true)
     .map(0x6C, ProtocolVersion::V1_21_5, true)
     .map(0x71, ProtocolVersion::V1_21_9, true)
+    .map(0x73, ProtocolVersion::V26_1, true)
     .register(&mut registry);
 
     // Transfer Clientbound (encode-only: proxy doesn't intercept)
@@ -587,6 +595,7 @@ pub fn build_default_registry() -> PacketRegistry {
     .map(0x73, ProtocolVersion::V1_20_5, true)
     .map(0x7A, ProtocolVersion::V1_21_2, true)
     .map(0x7F, ProtocolVersion::V1_21_9, true)
+    .map(0x81, ProtocolVersion::V26_1, true)
     .register(&mut registry);
 
     // StartConfiguration Clientbound (encode-only: proxy sends during server switch)
@@ -600,6 +609,7 @@ pub fn build_default_registry() -> PacketRegistry {
     .map(0x70, ProtocolVersion::V1_21_2, true)
     .map(0x6F, ProtocolVersion::V1_21_5, true)
     .map(0x74, ProtocolVersion::V1_21_9, true)
+    .map(0x76, ProtocolVersion::V26_1, true)
     .register(&mut registry);
 
     // GameEvent Clientbound (encode-only: used by Limbo engine)
@@ -731,6 +741,7 @@ pub fn build_default_registry() -> PacketRegistry {
     .map(0x0C, ProtocolVersion::V1_20_5, false)
     .map(0x0E, ProtocolVersion::V1_21_2, false)
     .map(0x0F, ProtocolVersion::V1_21_6, false)
+    .map(0x10, ProtocolVersion::V26_1, false)
     .register(&mut registry);
 
     // KeepAlive Serverbound
@@ -755,6 +766,7 @@ pub fn build_default_registry() -> PacketRegistry {
     .map(0x18, ProtocolVersion::V1_20_5, false)
     .map(0x1A, ProtocolVersion::V1_21_2, false)
     .map(0x1B, ProtocolVersion::V1_21_6, false)
+    .map(0x1C, ProtocolVersion::V26_1, false)
     .register(&mut registry);
 
     // ChatMessage Serverbound — registered as encode_only because the proxy
@@ -781,6 +793,7 @@ pub fn build_default_registry() -> PacketRegistry {
     .map(0x06, ProtocolVersion::V1_20_5, true)
     .map(0x07, ProtocolVersion::V1_21_2, true)
     .map(0x08, ProtocolVersion::V1_21_6, true)
+    .map(0x09, ProtocolVersion::V26_1, true)
     .register(&mut registry);
 
     // ChatCommand Serverbound (1.19+) — registered as encode_only because
@@ -797,6 +810,7 @@ pub fn build_default_registry() -> PacketRegistry {
     .map(0x04, ProtocolVersion::V1_20_5, true)
     .map(0x05, ProtocolVersion::V1_21_2, true)
     .map(0x06, ProtocolVersion::V1_21_6, true)
+    .map(0x07, ProtocolVersion::V26_1, true)
     .register(&mut registry);
 
     // Chat Session Update Serverbound (encode-only: proxy uses ID for filtering)
@@ -807,6 +821,7 @@ pub fn build_default_registry() -> PacketRegistry {
     .map(0x07, ProtocolVersion::V1_21, true)
     .map(0x08, ProtocolVersion::V1_21_2, true)
     .map(0x09, ProtocolVersion::V1_21_6, true)
+    .map(0x0A, ProtocolVersion::V26_1, true)
     .register(&mut registry);
 
     // PluginMessage Serverbound (encode-only: proxy doesn't intercept)
@@ -830,6 +845,7 @@ pub fn build_default_registry() -> PacketRegistry {
     .map(0x12, ProtocolVersion::V1_20_5, true)
     .map(0x14, ProtocolVersion::V1_21_2, true)
     .map(0x15, ProtocolVersion::V1_21_6, true)
+    .map(0x16, ProtocolVersion::V26_1, true)
     .register(&mut registry);
 
     registry

--- a/crates/infrarust_protocol/src/registry/mod.rs
+++ b/crates/infrarust_protocol/src/registry/mod.rs
@@ -222,7 +222,10 @@ mod tests {
     #![allow(clippy::unwrap_used, clippy::expect_used, clippy::panic)]
     use super::*;
     use crate::codec::{McBufWriteExt, VarInt};
-    use crate::packets::SHandshake;
+    use crate::packets::{
+        CEncryptionRequest, CLoginPluginRequest, CLoginSuccess, SHandshake, SLoginAcknowledged,
+        SLoginPluginResponse,
+    };
     use std::sync::Arc;
 
     fn make_handshake_payload(
@@ -350,6 +353,53 @@ mod tests {
                 ProtocolVersion::V1_9,
             ),
             Some(0x01)
+        );
+    }
+
+    #[test]
+    fn test_protocol_26_2_login_mappings() {
+        let registry = build_default_registry();
+        let version = ProtocolVersion::V26_2;
+
+        assert_eq!(
+            registry.get_packet_id::<CEncryptionRequest>(
+                ConnectionState::Login,
+                Direction::Clientbound,
+                version,
+            ),
+            Some(0x01)
+        );
+        assert_eq!(
+            registry.get_packet_id::<CLoginSuccess>(
+                ConnectionState::Login,
+                Direction::Clientbound,
+                version,
+            ),
+            Some(0x02)
+        );
+        assert_eq!(
+            registry.get_packet_id::<CLoginPluginRequest>(
+                ConnectionState::Login,
+                Direction::Clientbound,
+                version,
+            ),
+            Some(0x04)
+        );
+        assert_eq!(
+            registry.get_packet_id::<SLoginPluginResponse>(
+                ConnectionState::Login,
+                Direction::Serverbound,
+                version,
+            ),
+            Some(0x02)
+        );
+        assert_eq!(
+            registry.get_packet_id::<SLoginAcknowledged>(
+                ConnectionState::Login,
+                Direction::Serverbound,
+                version,
+            ),
+            Some(0x03)
         );
     }
 

--- a/crates/infrarust_protocol/src/version.rs
+++ b/crates/infrarust_protocol/src/version.rs
@@ -86,6 +86,10 @@ impl ProtocolVersion {
     pub const V1_21_9: Self = Self(773);
     /// Minecraft 1.21.11
     pub const V1_21_11: Self = Self(774);
+    /// Minecraft 26.1
+    pub const V26_1: Self = Self(775);
+    /// Minecraft 26.2
+    pub const V26_2: Self = Self(776);
 
     /// All supported protocol versions, sorted in ascending order.
     ///
@@ -126,6 +130,8 @@ impl ProtocolVersion {
         Self::V1_21_7,
         Self::V1_21_9,
         Self::V1_21_11,
+        Self::V26_1,
+        Self::V26_2,
     ];
 
     /// Returns `true` if `self >= other`.
@@ -201,6 +207,8 @@ impl ProtocolVersion {
             Self::V1_21_7 => "1.21.7",
             Self::V1_21_9 => "1.21.9",
             Self::V1_21_11 => "1.21.11",
+            Self::V26_1 => "26.1",
+            Self::V26_2 => "26.2",
             _ => "unknown",
         }
     }


### PR DESCRIPTION
## Summary

- complete the client login phase before connecting to a Velocity-forwarded backend in intercepted offline mode
- add protocol versions 775 and 776 with their updated packet mappings
- encode the mandatory Minecraft 26.2 server session UUID in LoginSuccess
- keep Velocity forwarding state scoped to the resolved forwarding handler

This allows Paper's modern Velocity forwarding handshake to receive the original client address in intercepted modes.

## Testing

- cargo test -p infrarust_protocol (277 passed)
- cargo test -p infrarust-core (all unit and integration tests passed)
- focused intercepted offline + Velocity login regression
- focused protocol 776 LoginSuccess session-ID round trip